### PR TITLE
Logging improvements

### DIFF
--- a/composition/composition_handler.go
+++ b/composition/composition_handler.go
@@ -64,7 +64,10 @@ func (agg *CompositionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			mergeContext.AddContent(res)
 
 		} else if res.Def.Required {
-			logging.Application(r.Header).WithField("fetchResult", res).Errorf("error loading content from: %v", res.Def.URL)
+			// 404 Error already become logged in logger.go
+			if res.Content.HttpStatusCode() != 404 {
+				logging.Application(r.Header).WithField("fetchResult", res).Errorf("error loading content from: %v", res.Def.URL)
+			}
 			res.Def.ErrHandler.Handle(res.Err, res.Content.HttpStatusCode(), w, r)
 			return
 		} else {

--- a/composition/content_fetcher.go
+++ b/composition/content_fetcher.go
@@ -100,10 +100,14 @@ func (fetcher *ContentFetcher) AddFetchJob(d *FetchDefinition) {
 				}
 			}
 		} else {
-			logging.Logger.WithError(fetchResult.Err).
-				WithField("fetchDefinition", d).
-				WithField("correlation_id", logging.GetCorrelationId(definitionCopy.Header)).
-				Errorf("failed fetching %v", d.URL)
+			// 404 Error already become logged in logger.go
+			if fetchResult.Content.HttpStatusCode() != 404 {
+				logging.Logger.WithError(fetchResult.Err).
+					WithField("fetchDefinition", d).
+					WithField("correlation_id", logging.GetCorrelationId(definitionCopy.Header)).
+					Errorf("failed fetching %v", d.URL)
+			}
+
 		}
 	}()
 }

--- a/composition/content_merge.go
+++ b/composition/content_merge.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"strings"
+	//	"fmt"
 )
 
 const (
@@ -42,7 +43,8 @@ func (cntx *ContentMerge) GetHtml() ([]byte, error) {
 	executeFragment = func(fragmentName string) error {
 		f, exist := cntx.Body[fragmentName]
 		if !exist {
-			return errors.New("Fragment does not exist: " + fragmentName)
+			missingFragmentString := generateMissingFragmentString(cntx.Body, fragmentName)
+			return errors.New(missingFragmentString)
 		}
 		return f.Execute(w, cntx.MetaJSON, executeFragment)
 	}
@@ -119,4 +121,22 @@ func urlToFragmentName(url string) string {
 	url = strings.Replace(url, `§[`, `\§\[`, -1)
 	url = strings.Replace(url, `]§`, `\]\§`, -1)
 	return url
+}
+
+// Generates String for the missing Fragment error message. It adds all existing fragments from the body
+func generateMissingFragmentString(body map[string]Fragment, fragmentName string) string {
+	text := "Fragment does not exist: " + fragmentName + " . Existing fragments: "
+	index := 0
+	for k, _ := range body {
+
+		if k != "" && !strings.Contains(k, "#") {
+			if index == 0 {
+				text += k
+			} else {
+				text += ", " + k
+			}
+			index++
+		}
+	}
+	return text
 }

--- a/composition/content_merge.go
+++ b/composition/content_merge.go
@@ -125,11 +125,11 @@ func urlToFragmentName(url string) string {
 
 // Generates String for the missing Fragment error message. It adds all existing fragments from the body
 func generateMissingFragmentString(body map[string]Fragment, fragmentName string) string {
-	text := "Fragment does not exist: " + fragmentName + " . Existing fragments: "
+	text := "Fragment does not exist: " + fragmentName + ". Existing fragments: "
 	index := 0
 	for k, _ := range body {
 
-		if k != "" && !strings.Contains(k, "#") {
+		if k != "" {
 			if index == 0 {
 				text += k
 			} else {

--- a/composition/content_merge_test.go
+++ b/composition/content_merge_test.go
@@ -62,6 +62,22 @@ func Test_ContentMerge_PositiveCase(t *testing.T) {
 type MockPage1BodyFragment struct {
 }
 
+func Test_GenerateMissingFragmentString(t *testing.T) {
+	body := map[string]Fragment{
+		"footer": nil,
+		"header": nil,
+		"":       nil,
+	}
+	fragmentName := "body"
+	fragmentString := generateMissingFragmentString(body, fragmentName)
+
+	a := assert.New(t)
+	a.Contains(fragmentString, "Fragment does not exist: body.")
+	a.Contains(fragmentString, "footer")
+	a.Contains(fragmentString, "header")
+
+}
+
 func (f MockPage1BodyFragment) Execute(w io.Writer, data map[string]interface{}, executeNestedFragment func(nestedFragmentName string) error) error {
 	w.Write([]byte("<page1-body-main>\n"))
 	if err := executeNestedFragment("page2-a"); err != nil {
@@ -86,7 +102,7 @@ func Test_ContentMerge_MainFragmentDoesNotExist(t *testing.T) {
 	cm := NewContentMerge(nil)
 	_, err := cm.GetHtml()
 	a.Error(err)
-	a.Equal("Fragment does not exist: ", err.Error())
+	a.Equal("Fragment does not exist: . Existing fragments: ", err.Error())
 }
 
 type closedWriterMock struct {

--- a/composition/http_content_loader.go
+++ b/composition/http_content_loader.go
@@ -1,13 +1,12 @@
 package composition
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
-
 	"errors"
+	"fmt"
 	"github.com/tarent/lib-compose/logging"
 	"net/url"
 )

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -80,6 +80,7 @@ func access(r *http.Request, start time.Time, statusCode int, err error) *logrus
 		"method":     r.Method,
 		"proto":      r.Proto,
 		"duration":   time.Since(start).Nanoseconds() / 1000000,
+		"User_Agent": r.Header.Get("User-Agent"),
 	}
 
 	if statusCode != 0 {

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -28,6 +28,7 @@ type logReccord struct {
 	Error             string            `json:"error"`
 	Message           string            `json:"message"`
 	Level             string            `json:"level"`
+	UserAgent         string            `json:"User_Agent"`
 }
 
 func Test_Logger_Set(t *testing.T) {
@@ -122,11 +123,14 @@ func Test_Logger_Access(t *testing.T) {
 	AccessLogCookiesBlacklist = []string{"ignore", "user_id"}
 	UserCorrelationCookie = "user_id"
 
+	// Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36
+
 	// and a request
 	r, _ := http.NewRequest("GET", "http://www.example.org/foo?q=bar", nil)
 	r.Header = http.Header{
 		CorrelationIdHeader: {"correlation-123"},
 		"Cookie":            {"user_id=user-id-xyz; ignore=me; foo=bar;"},
+		"User-Agent":        {"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36"},
 	}
 	r.RemoteAddr = "127.0.0.1"
 
@@ -153,6 +157,7 @@ func Test_Logger_Access(t *testing.T) {
 	a.Equal("access", data.Type)
 	a.Equal("/foo?q=bar", data.URL)
 	a.Equal("user-id-xyz", data.UserCorrelationId)
+	a.Equal("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36", data.UserAgent)
 }
 
 func Test_Logger_Access_ErrorCases(t *testing.T) {


### PR DESCRIPTION
UserAgent Header mit loggen
Besseres Logging von 404ern (Weniger Log-Zeilen), keine Darstellung als Fehler
Bei: 'Fragment not Found' Ausgabe der Liste aller ContentObjekte mit den zugehörigen Fragment-Namen