### PR TITLE
Pass on headers from original request.

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -49,7 +49,7 @@ func NewCache(name string, maxEntries int, maxSizeMB int, maxAge time.Duration) 
 	return c
 }
 
-// LogEvery Start a Goroutine, which logs statisitcs periodically.
+// LogEvery Start a Goroutine, which logs statistics periodically.
 func (c *Cache) LogEvery(d time.Duration) {
 	go c.logEvery(d)
 }

--- a/cache/cache_strategy.go
+++ b/cache/cache_strategy.go
@@ -100,7 +100,6 @@ func (tcs *CacheStrategy) HashWithParameters(method string, url string, requestH
 	}
 
 	hash := hex.EncodeToString(hasher.Sum(nil))
-//	logging.Logger.Error("HASH = " + hash + ", url = " + url + ", host = " + requestHeader.Get("Host"))
 	return hash
 }
 

--- a/cache/cache_strategy.go
+++ b/cache/cache_strategy.go
@@ -47,7 +47,7 @@ const (
 	ReasonResponseUncachableByDefault = cacheobject.ReasonResponseUncachableByDefault
 )
 
-var DefaultIncludeHeaders = []string{"Authorization", "Accept-Encoding"}
+var DefaultIncludeHeaders = []string{"Authorization", "Accept-Encoding", "Host"}
 
 var DefaultCacheStrategy = NewCacheStrategyWithDefault()
 
@@ -73,12 +73,12 @@ func NewCacheStrategy(includeHeaders []string, includeCookies []string, ignoreRe
 	}
 }
 
-// Hash computes a hash value based in the url, the method and selected header and cookien attributes,
+// Hash computes a hash value based on the url, the method and selected header and cookie attributes.
 func (tcs *CacheStrategy) Hash(method string, url string, requestHeader http.Header) string {
 	return tcs.HashWithParameters(method, url, requestHeader, tcs.includeHeaders, tcs.includeCookies)
 }
 
-// Hash computes a hash value based in the url, the method and selected header and cookien attributes,
+// Hash computes a hash value based on the url, the method and selected header and cookie attributes.
 func (tcs *CacheStrategy) HashWithParameters(method string, url string, requestHeader http.Header, includeHeaders []string, includeCookies []string) string {
 	hasher := md5.New()
 
@@ -99,7 +99,9 @@ func (tcs *CacheStrategy) HashWithParameters(method string, url string, requestH
 		}
 	}
 
-	return hex.EncodeToString(hasher.Sum(nil))
+	hash := hex.EncodeToString(hasher.Sum(nil))
+//	logging.Logger.Error("HASH = " + hash + ", url = " + url + ", host = " + requestHeader.Get("Host"))
+	return hash
 }
 
 func (tcs *CacheStrategy) IsCacheable(method string, url string, statusCode int, requestHeader http.Header, responseHeader http.Header) bool {

--- a/composition/composition_handler.go
+++ b/composition/composition_handler.go
@@ -41,6 +41,11 @@ func NewCompositionHandlerWithCache(contentFetcherFactory ContentFetcherFactory,
 }
 
 func (agg *CompositionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// If we know the host but don't have the Host header [any more] then we
+	// set [or restore] the header, because why would You just remove it!?:
+	if (r.Host != "") && (r.Header.Get("Host") == "") {
+		r.Header.Set("Host", r.Host)
+	}
 
 	fetcher := agg.contentFetcherFactory(r)
 

--- a/composition/composition_handler_test.go
+++ b/composition/composition_handler_test.go
@@ -480,6 +480,42 @@ func Test_getBaseUrlFromRequest(t *testing.T) {
 	}
 }
 
+
+// Jira 3946: go deletes the "Host" header from the request (for whatever reasons):
+// https://golang.org/src/net/http/request.go:
+//   123		// For incoming requests, the Host header is promoted to the
+//   124		// Request.Host field and removed from the Header map.
+// But our cache strategies might want this header in order to generate different
+// cache-IDs (hashes) for different host names (e.g. preview-mode-whatever.de vs. production-whatever.de).
+func Test_CompositionHandler_RestoreHostHeader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	a := assert.New(t)
+
+	contentFetcherFactory := func(r *http.Request) FetchResultSupplier {
+		return MockFetchResultSupplier{
+			&FetchResult{
+				Def: NewFetchDefinition("/foo"),
+				Content: &MemoryContent{
+					body: map[string]Fragment{
+						"": StringFragment("Hello World\n"),
+					},
+				},
+			},
+		}
+	}
+	ch := NewCompositionHandler(ContentFetcherFactory(contentFetcherFactory))
+
+	resp := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/", nil)
+	r.Host = "MyHost"
+	ch.ServeHTTP(resp, r)
+
+	a.Equal(200, resp.Code)
+	a.Equal("MyHost", r.Header.Get("Host"))
+}
+
+
 type MockFetchResultSupplier []*FetchResult
 
 func (m MockFetchResultSupplier) WaitForResults() []*FetchResult {

--- a/composition/content_fetcher.go
+++ b/composition/content_fetcher.go
@@ -62,7 +62,7 @@ func NewContentFetcher(defaultMetaJSON map[string]interface{}) *ContentFetcher {
 }
 
 // Wait blocks until all jobs are done,
-// eighter sucessful or with an error result and returns the content and errors.
+// either successful or with an error result and returns the content and errors.
 // Do we need to return the Results in a special order????
 func (fetcher *ContentFetcher) WaitForResults() []*FetchResult {
 	fetcher.activeJobs.Wait()
@@ -72,7 +72,7 @@ func (fetcher *ContentFetcher) WaitForResults() []*FetchResult {
 
 	results := fetcher.r.results
 
-	//to keep initial order if no priority settings are given, do a check before for sorting
+	// To keep initial order if no priority settings are given, do a check before for sorting.
 	if hasPrioritySetting(results) {
 		sort.Sort(FetchResults(results))
 	}
@@ -107,8 +107,8 @@ func (fetcher *ContentFetcher) AddFetchJob(d *FetchDefinition) {
 			return
 		}
 
-		// create a copy of the fetch definition, to because we do not
-		// want to override the original URL with expanded values
+		// Create a copy of the fetch definition, to because we do not
+		// want to override the original URL with expanded values.
 		definitionCopy := *d
 		definitionCopy.URL = url
 		fetchResult.Content, fetchResult.Err = fetcher.Loader.Load(&definitionCopy)
@@ -138,7 +138,7 @@ func (fetcher *ContentFetcher) Empty() bool {
 	return len(fetcher.r.results) == 0
 }
 
-// isAlreadyScheduled checks, if there is already a job for a FetchDefinition, or it is already fetched.
+// isAlreadyScheduled checks if there is already a job for a FetchDefinition, or it is already fetched.
 // The method has to be called in a locked mutex block.
 func (fetcher *ContentFetcher) isAlreadyScheduled(fetchDefinitionHash string) bool {
 	for _, fetchResult := range fetcher.r.results {

--- a/composition/content_fetcher_test.go
+++ b/composition/content_fetcher_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
         "sort"
-	"net/http"
 )
 
 func Test_ContentFetcher_FetchingWithDependency(t *testing.T) {
@@ -79,11 +78,10 @@ func getFetchDefinitionMock(ctrl *gomock.Controller, loaderMock *MockContentLoad
 
 func Test_ContentFetchResultPrioritySort(t *testing.T) {
         a := assert.New(t)
-	request := &http.Request{}
 
-        barFd := NewFetchDefinitionWithPriority("/bar", request, 30)
-        fooFd := NewFetchDefinitionWithPriority("/foo", request, 10)
-        bazzFd := NewFetchDefinitionWithPriority("/bazz", request, 5)
+        barFd := NewFetchDefinitionWithPriority("/bar", 30)
+        fooFd := NewFetchDefinitionWithPriority("/foo",  10)
+        bazzFd := NewFetchDefinitionWithPriority("/bazz",  5)
 
         results := []*FetchResult{{Def: barFd}, {Def: fooFd}, {Def: bazzFd}}
 

--- a/composition/content_fetcher_test.go
+++ b/composition/content_fetcher_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
         "sort"
+	"net/http"
 )
 
 func Test_ContentFetcher_FetchingWithDependency(t *testing.T) {
@@ -78,10 +79,11 @@ func getFetchDefinitionMock(ctrl *gomock.Controller, loaderMock *MockContentLoad
 
 func Test_ContentFetchResultPrioritySort(t *testing.T) {
         a := assert.New(t)
+	request := &http.Request{}
 
-        barFd := NewFetchDefinitionWithPriority("/bar", 30)
-        fooFd := NewFetchDefinitionWithPriority("/foo", 10)
-        bazzFd := NewFetchDefinitionWithPriority("/bazz", 5)
+        barFd := NewFetchDefinitionWithPriority("/bar", request, 30)
+        fooFd := NewFetchDefinitionWithPriority("/foo", request, 10)
+        bazzFd := NewFetchDefinitionWithPriority("/bazz", request, 5)
 
         results := []*FetchResult{{Def: barFd}, {Def: fooFd}, {Def: bazzFd}}
 

--- a/composition/content_merge_test.go
+++ b/composition/content_merge_test.go
@@ -52,7 +52,9 @@ func Test_ContentMerge_PositiveCase(t *testing.T) {
 	cm := NewContentMerge(nil)
 	cm.AddContent(asFetchResult(page1))
 	cm.AddContent(asFetchResult(page2))
-	cm.AddContent(asFetchResult(page3))
+	fetchResult3 := asFetchResult(page3)
+	fetchResult3.Def.Priority = MAX_PRIORITY // just to trigger the priority-parsing and see that it doesn't crash...
+	cm.AddContent(fetchResult3)
 
 	html, err := cm.GetHtml()
 	a.NoError(err)

--- a/composition/fetch_definition.go
+++ b/composition/fetch_definition.go
@@ -94,9 +94,12 @@ func NewFetchDefinition(url string) *FetchDefinition {
 	}
 }
 
-func NewFetchDefinitionWithPriority(url string, r *http.Request, priority int) *FetchDefinition {
-	return NewFetchDefinitionWithResponseProcessorAndPriority(url, nil, r, priority)
+func NewFetchDefinitionWithPriority(url string, priority int) *FetchDefinition {
+	fd := NewFetchDefinition(url)
+	fd.Priority = priority
+	return fd
 }
+
 
 // If a ResponseProcessor-Implementation is given it can be used to change the response before composition
 // Priority is used to determine which property from which head has to be taken by collision of multiple fetches

--- a/composition/fetch_definition.go
+++ b/composition/fetch_definition.go
@@ -31,6 +31,7 @@ var ForwardRequestHeaders = []string{
 	"X-Forwarded-Host",
 	"X-Correlation-Id",
 	"X-Feature-Toggle",
+	"Host",
 }
 
 // ForwardResponseHeaders are those headers,
@@ -75,48 +76,37 @@ type FetchDefinition struct {
 	Priority               int
 }
 
-// Creates a fetch definition
+// All the FetchDefinitions, that get passed a request, will forward the ForwardRequestHeaders. But only
+// those that are *FromRequest will also append the original requests other information, like method, body, URL.
+
+
+// Creates a fetch definition (warning: this one will not forward any request headers).
 func NewFetchDefinition(url string) *FetchDefinition {
-	return NewFetchDefinitionWithResponseProcessorAndPriority(url, nil, DefaultPriority)
-}
-
-func NewFetchDefinitionWithPriority(url string, priority int) *FetchDefinition {
-	return NewFetchDefinitionWithResponseProcessorAndPriority(url, nil, priority)
-}
-
-func NewFetchDefinitionWithErrorHandler(url string, errHandler ErrorHandler) *FetchDefinition {
-	return NewFetchDefinitionWithErrorHandlerAndPriority(url, errHandler, DefaultPriority)
-}
-
-func NewFetchDefinitionWithErrorHandlerAndPriority(url string, errHandler ErrorHandler, priority int) *FetchDefinition {
-	if errHandler == nil {
-		errHandler = NewDefaultErrorHandler()
-	}
 	return &FetchDefinition{
 		URL:             url,
 		Timeout:         DefaultTimeout,
 		FollowRedirects: false,
 		Required:        true,
 		Method:          "GET",
-		ErrHandler:      errHandler,
+		ErrHandler:      NewDefaultErrorHandler(),
 		CacheStrategy:   cache.DefaultCacheStrategy,
-		Priority:        priority,
+		Priority:        DefaultPriority,
 	}
 }
 
-// If a ResponseProcessor-Implementation is given it can be used to change the response before composition
-func NewFetchDefinitionWithResponseProcessor(url string, rp ResponseProcessor) *FetchDefinition {
-	return NewFetchDefinitionWithResponseProcessorAndPriority(url, rp, DefaultPriority)
+func NewFetchDefinitionWithPriority(url string, r *http.Request, priority int) *FetchDefinition {
+	return NewFetchDefinitionWithResponseProcessorAndPriority(url, nil, r, priority)
 }
 
 // If a ResponseProcessor-Implementation is given it can be used to change the response before composition
 // Priority is used to determine which property from which head has to be taken by collision of multiple fetches
-func NewFetchDefinitionWithResponseProcessorAndPriority(url string, rp ResponseProcessor, priority int) *FetchDefinition {
+func NewFetchDefinitionWithResponseProcessorAndPriority(url string, rp ResponseProcessor, r *http.Request, priority int) *FetchDefinition {
 	return &FetchDefinition{
 		URL:             url,
 		Timeout:         DefaultTimeout,
 		FollowRedirects: false,
 		Required:        true,
+		Header:          copyHeaders(r.Header, nil, ForwardRequestHeaders),
 		Method:          "GET",
 		RespProc:        rp,
 		ErrHandler:      NewDefaultErrorHandler(),

--- a/composition/fetch_definition_test.go
+++ b/composition/fetch_definition_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"net/url"
 )
 
 func Test_FetchDefinition_NewFetchDefinitionFromRequest(t *testing.T) {
@@ -44,16 +45,19 @@ func Test_FetchDefinition_NewFetchDefinitionFromRequest(t *testing.T) {
 func Test_FetchDefinition_use_DefaultErrorHandler_if_not_set(t *testing.T) {
 	a := assert.New(t)
 
-	fd := NewFetchDefinitionWithErrorHandler("http://upstream:8080/", nil)
+	fd := NewFetchDefinition("http://upstream:8080/")
 	a.Equal(NewDefaultErrorHandler(), fd.ErrHandler)
 }
 
 
 func Test_FetchDefinition_NewFunctions_have_default_priority(t *testing.T) {
 	a := assert.New(t)
+	request := &http.Request{}
+	request.URL = &url.URL{}
+
 	fd1 := NewFetchDefinition("foo")
-	fd2 := NewFetchDefinitionWithErrorHandler("baa", nil)
-	fd3 := NewFetchDefinitionWithResponseProcessor("blub", nil)
+	fd2 := NewFetchDefinitionFromRequest("baa", request)
+	fd3 := NewFetchDefinitionWithResponseProcessorFromRequest("blub", request, nil)
 
 	r, err := http.NewRequest("POST", "https://example.com/content?foo=bar", nil)
 	a.NoError(err)
@@ -69,9 +73,12 @@ func Test_FetchDefinition_NewFunctions_have_default_priority(t *testing.T) {
 
 func Test_FetchDefinition_NewFunctions_have_parameter_priority(t *testing.T) {
 	a := assert.New(t)
-	fd1 := NewFetchDefinitionWithPriority("foo", 42)
-	fd2 := NewFetchDefinitionWithErrorHandlerAndPriority("baa", nil, 54)
-	fd3 := NewFetchDefinitionWithResponseProcessorAndPriority("blub", nil, 74)
+	request := &http.Request{}
+	request.URL = &url.URL{}
+
+	fd1 := NewFetchDefinitionWithPriority("foo", request, 42)
+	fd2 := NewFetchDefinitionWithPriorityFromRequest("baa", request, 54)
+	fd3 := NewFetchDefinitionWithResponseProcessorAndPriorityFromRequest("blub", request, nil, 74)
 
 
 	r, err := http.NewRequest("POST", "https://example.com/content?foo=bar", nil)

--- a/composition/fetch_definition_test.go
+++ b/composition/fetch_definition_test.go
@@ -76,7 +76,7 @@ func Test_FetchDefinition_NewFunctions_have_parameter_priority(t *testing.T) {
 	request := &http.Request{}
 	request.URL = &url.URL{}
 
-	fd1 := NewFetchDefinitionWithPriority("foo", request, 42)
+	fd1 := NewFetchDefinitionWithPriority("foo", 42)
 	fd2 := NewFetchDefinitionWithPriorityFromRequest("baa", request, 54)
 	fd3 := NewFetchDefinitionWithResponseProcessorAndPriorityFromRequest("blub", request, nil, 74)
 

--- a/composition/http_content_loader_test.go
+++ b/composition/http_content_loader_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"github.com/tarent/lib-servicediscovery/servicediscovery"
 	"fmt"
+	"net/url"
 )
 
 func Test_HttpContentLoader_Load(t *testing.T) {
@@ -48,6 +49,8 @@ func Test_HttpContentLoader_Load_ResponseProcessor(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	a := assert.New(t)
+	request := &http.Request{}
+	request.URL = &url.URL{}
 
 	server := testServer("the body", time.Millisecond*0)
 	defer server.Close()
@@ -66,11 +69,11 @@ func Test_HttpContentLoader_Load_ResponseProcessor(t *testing.T) {
 
 	mockResponseProcessor := NewMockResponseProcessor(ctrl)
 	mockResponseProcessor.EXPECT().Process(gomock.Any(), gomock.Any())
-	c, err := loader.Load(NewFetchDefinitionWithResponseProcessor(server.URL, mockResponseProcessor))
+	c, err := loader.Load(NewFetchDefinitionWithResponseProcessorFromRequest(server.URL, request, mockResponseProcessor))
 	a.NoError(err)
 	a.NotNil(c)
 	a.Nil(c.Reader())
-	a.Equal(server.URL, c.URL())
+	a.Equal(server.URL + "/", c.URL()) // rob: I don't know why the server doesn't include the trailing slash but I think the fetchdefinition-URL is ok in doing so...
 	eqFragment(t, "some head content", c.Head())
 	a.Equal(0, len(c.Body()))
 }


### PR DESCRIPTION
The Host header, which is automatically deleted by go, is restored and, together with the other headers from the original request, is passed on to the FetchDefinitions.
That way we can make caching decisions based on the host, for services that handle more than one host, with same paths but different content.