### PR TITLE
fixed the logrus dependencies by including logstash formater

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,7 +1,7 @@
 package cache
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/tarent/logrus"
 	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/tarent/lib-compose/logging"
 	"sync"

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -3,8 +3,7 @@ package logging
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Sirupsen/logrus"
-	logstash "github.com/bshuster-repo/logrus-logstash-hook"
+	"github.com/tarent/logrus"
 	"net/http"
 	"os"
 	"strings"
@@ -33,7 +32,7 @@ func Set(level string, textLogging bool) error {
 	if textLogging {
 		logger.Formatter = &logrus.TextFormatter{}
 	} else {
-		logger.Formatter = &logstash.LogstashFormatter{TimestampFormat: time.RFC3339Nano}
+		logger.Formatter = &LogstashFormatter{TimestampFormat: time.RFC3339Nano}
 	}
 	logger.Level = l
 	Logger = logger

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"github.com/Sirupsen/logrus"
+	"github.com/tarent/logrus"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"os"

--- a/logging/logstash_formatter.go
+++ b/logging/logstash_formatter.go
@@ -1,0 +1,84 @@
+package logging
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/tarent/logrus"
+)
+
+// Taken from github.com/bshuster-repo/logrus-logstash-hook
+// MIT License (MIT)
+// Copyright (c) 2016 Boaz Shuster
+
+// Formatter generates json in logstash format.
+// Logstash site: http://logstash.net/
+type LogstashFormatter struct {
+	Type string // if not empty use for logstash type field.
+
+	// TimestampFormat sets the format used for timestamps.
+	TimestampFormat string
+}
+
+func (f *LogstashFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	return f.FormatWithPrefix(entry, "")
+}
+
+func (f *LogstashFormatter) FormatWithPrefix(entry *logrus.Entry, prefix string) ([]byte, error) {
+	fields := make(logrus.Fields)
+	for k, v := range entry.Data {
+		//remvove the prefix when sending the fields to logstash
+		if prefix != "" && strings.HasPrefix(k, prefix) {
+			k = strings.TrimPrefix(k, prefix)
+		}
+
+		switch v := v.(type) {
+		case error:
+			// Otherwise errors are ignored by `encoding/json`
+			// https://github.com/Sirupsen/logrus/issues/377
+			fields[k] = v.Error()
+		default:
+			fields[k] = v
+		}
+	}
+
+	fields["@version"] = "1"
+
+	timeStampFormat := f.TimestampFormat
+
+	if timeStampFormat == "" {
+		timeStampFormat = logrus.DefaultTimestampFormat
+	}
+
+	fields["@timestamp"] = entry.Time.Format(timeStampFormat)
+
+	// set message field
+	v, ok := entry.Data["message"]
+	if ok {
+		fields["fields.message"] = v
+	}
+	fields["message"] = entry.Message
+
+	// set level field
+	v, ok = entry.Data["level"]
+	if ok {
+		fields["fields.level"] = v
+	}
+	fields["level"] = entry.Level.String()
+
+	// set type field
+	if f.Type != "" {
+		v, ok = entry.Data["type"]
+		if ok {
+			fields["fields.type"] = v
+		}
+		fields["type"] = f.Type
+	}
+
+	serialized, err := json.Marshal(fields)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
+	}
+	return append(serialized, '\n'), nil
+}

--- a/logging/logstash_formatter_test.go
+++ b/logging/logstash_formatter_test.go
@@ -1,0 +1,76 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/tarent/logrus"
+)
+
+// Taken from github.com/bshuster-repo/logrus-logstash-hook
+// MIT License (MIT)
+// Copyright (c) 2016 Boaz Shuster
+
+func TestLogstashFormatter(t *testing.T) {
+	lf := LogstashFormatter{Type: "abc"}
+
+	fields := logrus.Fields{
+		"message": "def",
+		"level":   "ijk",
+		"type":    "lmn",
+		"one":     1,
+		"pi":      3.14,
+		"bool":    true,
+		"error":   &url.Error{Op: "Get", URL: "http://example.com", Err: fmt.Errorf("The error")},
+	}
+
+	entry := logrus.WithFields(fields)
+	entry.Message = "msg"
+	entry.Level = logrus.InfoLevel
+
+	b, _ := lf.Format(entry)
+
+	var data map[string]interface{}
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
+	dec.Decode(&data)
+
+	// base fields
+	if data["@timestamp"] == "" {
+		t.Error("expected @timestamp to be not empty")
+	}
+	tt := []struct {
+		expected string
+		key      string
+	}{
+		// base fields
+		{"1", "@version"},
+		{"abc", "type"},
+		{"msg", "message"},
+		{"info", "level"},
+		{"Get http://example.com: The error", "error"},
+		// substituted fields
+		{"def", "fields.message"},
+		{"ijk", "fields.level"},
+		{"lmn", "fields.type"},
+	}
+	for _, te := range tt {
+		if te.expected != data[te.key] {
+			t.Errorf("expected data[%s] to be '%s' but got '%s'", te.key, te.expected, data[te.key])
+		}
+	}
+
+	// formats
+	if json.Number("1") != data["one"] {
+		t.Errorf("expected one to be '%v' but got '%v'", json.Number("1"), data["one"])
+	}
+	if json.Number("3.14") != data["pi"] {
+		t.Errorf("expected pi to be '%v' but got '%v'", json.Number("3.14"), data["pi"])
+	}
+	if true != data["bool"] {
+		t.Errorf("expected bool to be '%v' but got '%v'", true, data["bool"])
+	}
+}


### PR DESCRIPTION
This PR now changed the logging dependencies
by pointing to the tarent fork and including the logstash formatter.
@domano I hope, we've not done the work twice, now.

Fixes #47 