### PR TITLE
Provide a deduplication strategy for stylesheets.

### DIFF
--- a/composition/content_merge.go
+++ b/composition/content_merge.go
@@ -58,7 +58,8 @@ func (cntx *ContentMerge) collectStylesheets(f Fragment) {
 }
 
 func (cntx *ContentMerge) writeStylesheets(w io.Writer) {
-	for _, href := range cntx.stylesheets {
+	stylesheets := stylesheetDeduplicationStrategy.Deduplicate(cntx.stylesheets)
+	for _, href := range stylesheets {
 		stylesheet := fmt.Sprintf("\n    <link rel=\"stylesheet\" type=\"text/css\" href=\"%s\">", href)
 		io.WriteString(w, stylesheet)
 	}

--- a/composition/interfaces.go
+++ b/composition/interfaces.go
@@ -15,7 +15,7 @@ type Fragment interface {
 
 	// MemorySize return the estimated size in bytes, for this object in memory
 	MemorySize() int
-	
+
 	// Return the list of stylesheets used in this fragment
 	Stylesheets() []string
 }
@@ -121,4 +121,8 @@ type Cache interface {
 	Set(hash string, label string, memorySize int, cacheObject interface{})
 	Invalidate()
 	PurgeEntries(keys []string)
+}
+
+type StylesheetDeduplicationStrategy interface {
+	Deduplicate(hrefs []string) []string
 }

--- a/composition/stylesheet_deduplication.go
+++ b/composition/stylesheet_deduplication.go
@@ -1,0 +1,45 @@
+package composition
+
+import "strings"
+
+// Initialization: Sets the default deduplication strategy to be used.
+func init() {
+	SetStrategy(new(IdentityDeduplicationStrategy))
+}
+
+// Set another deduplication strategy.
+func SetStrategy(strategy StylesheetDeduplicationStrategy) {
+	stylesheetDeduplicationStrategy = strategy
+}
+
+// NOOP strategy.
+// This stragegy will insert all found stylesheets w/o any filtering.
+type IdentityDeduplicationStrategy struct {
+}
+
+func (strategy *IdentityDeduplicationStrategy) Deduplicate(hrefs []string) []string {
+	return hrefs
+}
+
+// Simple strategy
+// Implements a very simple deduplication stragegy. That is, it filters out
+// stylesheets with duplicate href value.
+type SimpleDeduplicationStrategy struct {
+}
+
+// Remove duplicate entries from hrefs.
+func (strategy *SimpleDeduplicationStrategy) Deduplicate(hrefs []string) []string {
+	var knownHrefs string
+	var result []string
+	const delimiter = "-|-"
+	for _, href := range hrefs {
+		if !strings.Contains(knownHrefs, href) {
+			result = append(result, href)
+			knownHrefs += delimiter + href
+		}
+	}
+	return result
+}
+
+// Variable to hold the active strategy
+var stylesheetDeduplicationStrategy StylesheetDeduplicationStrategy

--- a/composition/stylesheet_deduplication_test.go
+++ b/composition/stylesheet_deduplication_test.go
@@ -1,0 +1,47 @@
+package composition
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_DefaultDeduplicationStrategy(t *testing.T) {
+	a := assert.New(t)
+	stylesheets := []string{"a", "b"}
+	result := stylesheetDeduplicationStrategy.Deduplicate(stylesheets)
+	a.EqualValues(stylesheets, result)
+}
+
+func Test_SimpleDeduplicationStrategy(t *testing.T) {
+	a := assert.New(t)
+	stylesheets := []string{"a", "b", "a", "b", "c", "a"}
+	deduper := new(SimpleDeduplicationStrategy)
+	result := deduper.Deduplicate(stylesheets)
+	a.EqualValues([]string{"a", "b", "c"}, result)
+}
+
+type Strategy struct {
+	collecttion []string
+}
+
+func (strategy *Strategy) Deduplicate(hrefs []string) []string {
+	newhrefs := []string{}
+	for _, href := range hrefs {
+		newhrefs = append(newhrefs, href+"?abcdef")
+		strategy.collecttion = append(strategy.collecttion, href)
+	}
+	return newhrefs
+}
+
+func Test_OwnDeduplicationStrategy(t *testing.T) {
+	strategy := new(Strategy)
+	SetStrategy(strategy)
+
+	a := assert.New(t)
+	stylesheets := []string{"a", "b"}
+	expected := []string{"a?abcdef", "b?abcdef"}
+	result := stylesheetDeduplicationStrategy.Deduplicate(stylesheets)
+	a.EqualValues(expected, result)
+	a.EqualValues(strategy.collecttion, stylesheets)
+}

--- a/composition_example/example_ui_service.go
+++ b/composition_example/example_ui_service.go
@@ -53,3 +53,17 @@ func sidebarHandler(w http.ResponseWriter, r *http.Request) {
 	teaserId := r.URL.Query().Get("teaser-id")
 	fmt.Fprintf(w, template, teaserId)
 }
+
+
+// Use an own deduplication strategy instead of the default one
+
+type MyExampleDeduplicationStrategy struct {
+}
+
+func (strategy *MyExampleDeduplicationStrategy) Deduplicate(hrefs []string) []string {
+	return hrefs
+}
+
+func init() {
+	composition.SetStrategy(new(MyExampleDeduplicationStrategy))
+}


### PR DESCRIPTION
The user of the library can implement her own strategy and set it via
composition.SetStrategy().

The library will provide two strategies:
- IdentityDeduplicationStrategy (NOOP strategy)
- SimpleDeduplicationStrategy (uniqueness by the full href path to stylesheets)