### PR TITLE
Provide a deduplication strategy for stylesheets.

### DIFF
--- a/composition/content_merge.go
+++ b/composition/content_merge.go
@@ -66,12 +66,18 @@ func (cntx *ContentMerge) collectStylesheets(f Fragment) {
 	cntx.stylesheets = append(cntx.stylesheets, f.Stylesheets()...)
 }
 
-func (cntx *ContentMerge) writeStylesheets(w io.Writer) {
-	stylesheets := cntx.stylesheets
+func (cntx *ContentMerge) deduplicateStylesheets() {
 	if cntx.stylesheetDeduplicationStrategy != nil {
-		stylesheets = cntx.stylesheetDeduplicationStrategy.Deduplicate(cntx.stylesheets)
+		cntx.stylesheets = cntx.stylesheetDeduplicationStrategy.Deduplicate(cntx.stylesheets)
 	}
-	for _, attrs := range stylesheets {
+}
+
+func (cntx *ContentMerge) writeStylesheets(w io.Writer) {
+
+	// first make sure, stylesheets are deduplicated
+	cntx.deduplicateStylesheets()
+
+	for _, attrs := range cntx.stylesheets {
 		joinedAttr := joinAttrs(attrs)
 		stylesheet := fmt.Sprintf("\n    <link %s>", joinedAttr)
 		io.WriteString(w, stylesheet)

--- a/composition/content_merge.go
+++ b/composition/content_merge.go
@@ -60,7 +60,8 @@ func (cntx *ContentMerge) collectStylesheets(f Fragment) {
 }
 
 func (cntx *ContentMerge) writeStylesheets(w io.Writer) {
-	for _, attrs := range cntx.stylesheets {
+	stylesheets := stylesheetDeduplicationStrategy.Deduplicate(cntx.stylesheets)
+	for _, attrs := range stylesheets {
 		joinedAttr := joinAttrs(attrs)
 		stylesheet := fmt.Sprintf("\n    <link %s>", joinedAttr)
 		io.WriteString(w, stylesheet)

--- a/composition/content_merge_test.go
+++ b/composition/content_merge_test.go
@@ -8,11 +8,6 @@ import (
 	"golang.org/x/net/html"
 )
 
-func stylesheetAttrs(href string) []html.Attribute {
-	commonAttr := []html.Attribute{{Key: "rel", Val: "stylesheet"}, {Key: "type", Val: "text/css"}}
-	return append(commonAttr, html.Attribute{Key: "href", Val: href})
-}
-
 func Test_ContentMerge_PositiveCase(t *testing.T) {
 	a := assert.New(t)
 

--- a/composition/interface_mocks_test.go
+++ b/composition/interface_mocks_test.go
@@ -5,7 +5,7 @@ package composition
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	
+
 	io "io"
 	http "net/http"
 )
@@ -258,6 +258,9 @@ func (_m *MockContentMerger) GetHtml() ([]byte, error) {
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
+}
+
+func (_m *MockContentMerger) SetDeduplicationStrategy(strategy StylesheetDeduplicationStrategy) {
 }
 
 func (_mr *_MockContentMergerRecorder) GetHtml() *gomock.Call {

--- a/composition/interfaces.go
+++ b/composition/interfaces.go
@@ -124,3 +124,7 @@ type Cache interface {
 	Invalidate()
 	PurgeEntries(keys []string)
 }
+
+type StylesheetDeduplicationStrategy interface {
+	Deduplicate(stylesheetAttrs [][]html.Attribute) [][]html.Attribute
+}

--- a/composition/interfaces.go
+++ b/composition/interfaces.go
@@ -105,6 +105,9 @@ type ContentMerger interface {
 
 	// Return the html as byte array
 	GetHtml() ([]byte, error)
+
+	// Set the stratgy for stylesheet deduplication
+	SetDeduplicationStrategy(stategy StylesheetDeduplicationStrategy)
 }
 
 type ResponseProcessor interface {

--- a/composition/stylesheet_deduplication.go
+++ b/composition/stylesheet_deduplication.go
@@ -1,11 +1,8 @@
 package composition
 
 import (
-	"strings"
-
 	"golang.org/x/net/html"
 )
-
 
 // NOOP strategy.
 // This strategy will insert all found stylesheets w/o any filtering.
@@ -24,17 +21,18 @@ type SimpleDeduplicationStrategy struct {
 
 // Remove duplicate entries from hrefs.
 func (strategy *SimpleDeduplicationStrategy) Deduplicate(stylesheets [][]html.Attribute) (result [][]html.Attribute) {
-	var knownHrefs string
-	const delimiter = "-|-"
+	knownHrefs := map[string]bool{}
+	var meaninglessValue bool
 	for _, stylesheetAttrs := range stylesheets {
 		hrefAttr, attrExists := getAttr(stylesheetAttrs, "href")
 		if !attrExists {
 			continue
 		}
 		href := hrefAttr.Val
-		if !strings.Contains(knownHrefs, href) {
+		_, known := knownHrefs[href]
+		if !known {
 			result = append(result, stylesheetAttrs)
-			knownHrefs += delimiter + href
+			knownHrefs[href] = meaninglessValue
 		}
 	}
 	return result

--- a/composition/stylesheet_deduplication.go
+++ b/composition/stylesheet_deduplication.go
@@ -21,8 +21,7 @@ type SimpleDeduplicationStrategy struct {
 
 // Remove duplicate entries from hrefs.
 func (strategy *SimpleDeduplicationStrategy) Deduplicate(stylesheets [][]html.Attribute) (result [][]html.Attribute) {
-	knownHrefs := map[string]bool{}
-	var meaninglessValue bool
+	knownHrefs := map[string]struct{}{}
 	for _, stylesheetAttrs := range stylesheets {
 		hrefAttr, attrExists := getAttr(stylesheetAttrs, "href")
 		if !attrExists {
@@ -32,7 +31,7 @@ func (strategy *SimpleDeduplicationStrategy) Deduplicate(stylesheets [][]html.At
 		_, known := knownHrefs[href]
 		if !known {
 			result = append(result, stylesheetAttrs)
-			knownHrefs[href] = meaninglessValue
+			knownHrefs[href] = struct{}{}
 		}
 	}
 	return result

--- a/composition/stylesheet_deduplication.go
+++ b/composition/stylesheet_deduplication.go
@@ -1,0 +1,53 @@
+package composition
+
+import (
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// Initialization: Sets the default deduplication strategy to be used.
+func init() {
+	SetStrategy(new(IdentityDeduplicationStrategy))
+}
+
+// Set another deduplication strategy.
+func SetStrategy(strategy StylesheetDeduplicationStrategy) {
+	stylesheetDeduplicationStrategy = strategy
+}
+
+// NOOP strategy.
+// This stragegy will insert all found stylesheets w/o any filtering.
+type IdentityDeduplicationStrategy struct {
+}
+
+func (strategy *IdentityDeduplicationStrategy) Deduplicate(stylesheets [][]html.Attribute) [][]html.Attribute {
+	return stylesheets
+}
+
+// Simple strategy
+// Implements a very simple deduplication stragegy. That is, it filters out
+// stylesheets with duplicate href value.
+type SimpleDeduplicationStrategy struct {
+}
+
+// Remove duplicate entries from hrefs.
+func (strategy *SimpleDeduplicationStrategy) Deduplicate(stylesheets [][]html.Attribute) (result [][]html.Attribute) {
+	var knownHrefs string
+	const delimiter = "-|-"
+	for _, stylesheetAttrs := range stylesheets {
+		hrefAttr, attrExists := getAttr(stylesheetAttrs, "href")
+		if !attrExists {
+			continue
+		}
+		href := hrefAttr.Val
+		if !strings.Contains(knownHrefs, href) {
+			result = append(result, stylesheetAttrs)
+			knownHrefs += delimiter + href
+		}
+	}
+	return result
+}
+
+// Variable to hold the active strategy
+var stylesheetDeduplicationStrategy StylesheetDeduplicationStrategy

--- a/composition/stylesheet_deduplication.go
+++ b/composition/stylesheet_deduplication.go
@@ -6,18 +6,9 @@ import (
 	"golang.org/x/net/html"
 )
 
-// Initialization: Sets the default deduplication strategy to be used.
-func init() {
-	SetStrategy(new(IdentityDeduplicationStrategy))
-}
-
-// Set another deduplication strategy.
-func SetStrategy(strategy StylesheetDeduplicationStrategy) {
-	stylesheetDeduplicationStrategy = strategy
-}
 
 // NOOP strategy.
-// This stragegy will insert all found stylesheets w/o any filtering.
+// This strategy will insert all found stylesheets w/o any filtering.
 type IdentityDeduplicationStrategy struct {
 }
 
@@ -26,7 +17,7 @@ func (strategy *IdentityDeduplicationStrategy) Deduplicate(stylesheets [][]html.
 }
 
 // Simple strategy
-// Implements a very simple deduplication stragegy. That is, it filters out
+// Implements a very simple deduplication strategy. That is, it filters out
 // stylesheets with duplicate href value.
 type SimpleDeduplicationStrategy struct {
 }
@@ -48,6 +39,3 @@ func (strategy *SimpleDeduplicationStrategy) Deduplicate(stylesheets [][]html.At
 	}
 	return result
 }
-
-// Variable to hold the active strategy
-var stylesheetDeduplicationStrategy StylesheetDeduplicationStrategy

--- a/composition/stylesheet_deduplication_test.go
+++ b/composition/stylesheet_deduplication_test.go
@@ -13,10 +13,11 @@ func stylesheetAttrs(href string) []html.Attribute {
 	return append(commonAttr, html.Attribute{Key: "href", Val: href})
 }
 
-func Test_DefaultDeduplicationStrategy(t *testing.T) {
+func Test_IdentityDeduplicationStrategy(t *testing.T) {
 	a := assert.New(t)
 	stylesheets := [][]html.Attribute{stylesheetAttrs("/a"), stylesheetAttrs("/b")}
-	result := stylesheetDeduplicationStrategy.Deduplicate(stylesheets)
+	deduper := new(IdentityDeduplicationStrategy)
+	result := deduper.Deduplicate(stylesheets)
 	a.EqualValues(stylesheets, result)
 }
 
@@ -51,25 +52,4 @@ func (strategy *Strategy) Deduplicate(stylesheets [][]html.Attribute) (result []
 		}
 	}
 	return result
-}
-
-func Test_OwnDeduplicationStrategy(t *testing.T) {
-	strategy := new(Strategy)
-	SetStrategy(strategy)
-
-	a := assert.New(t)
-	stylesheets := [][]html.Attribute{
-		stylesheetAttrs("/a"),
-		stylesheetAttrs("/b"),
-		stylesheetAttrs("/c"),
-		stylesheetAttrs("/d"),
-		stylesheetAttrs("/e"),
-	}
-	expected := [][]html.Attribute{
-		stylesheetAttrs("/a"),
-		stylesheetAttrs("/c"),
-		stylesheetAttrs("/e"),
-	}
-	result := stylesheetDeduplicationStrategy.Deduplicate(stylesheets)
-	a.EqualValues(expected, result)
 }

--- a/composition/stylesheet_deduplication_test.go
+++ b/composition/stylesheet_deduplication_test.go
@@ -1,0 +1,75 @@
+package composition
+
+import (
+	"testing"
+
+	"golang.org/x/net/html"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func stylesheetAttrs(href string) []html.Attribute {
+	commonAttr := []html.Attribute{{Key: "rel", Val: "stylesheet"}, {Key: "type", Val: "text/css"}}
+	return append(commonAttr, html.Attribute{Key: "href", Val: href})
+}
+
+func Test_DefaultDeduplicationStrategy(t *testing.T) {
+	a := assert.New(t)
+	stylesheets := [][]html.Attribute{stylesheetAttrs("/a"), stylesheetAttrs("/b")}
+	result := stylesheetDeduplicationStrategy.Deduplicate(stylesheets)
+	a.EqualValues(stylesheets, result)
+}
+
+func Test_SimpleDeduplicationStrategy(t *testing.T) {
+	a := assert.New(t)
+	stylesheets := [][]html.Attribute{
+		stylesheetAttrs("/a"),
+		stylesheetAttrs("/b"),
+		stylesheetAttrs("/a"),
+		stylesheetAttrs("/b"),
+		stylesheetAttrs("/c"),
+		stylesheetAttrs("/a"),
+	}
+	expected := [][]html.Attribute{
+		stylesheetAttrs("/a"),
+		stylesheetAttrs("/b"),
+		stylesheetAttrs("/c"),
+	}
+	deduper := new(SimpleDeduplicationStrategy)
+	result := deduper.Deduplicate(stylesheets)
+	a.EqualValues(expected, result)
+}
+
+// Tests for setting an own deduplication strategy
+type Strategy struct {
+}
+
+func (strategy *Strategy) Deduplicate(stylesheets [][]html.Attribute) (result [][]html.Attribute) {
+	for i, stylesheetAttrs := range stylesheets {
+		if i%2 == 0 {
+			result = append(result, stylesheetAttrs)
+		}
+	}
+	return result
+}
+
+func Test_OwnDeduplicationStrategy(t *testing.T) {
+	strategy := new(Strategy)
+	SetStrategy(strategy)
+
+	a := assert.New(t)
+	stylesheets := [][]html.Attribute{
+		stylesheetAttrs("/a"),
+		stylesheetAttrs("/b"),
+		stylesheetAttrs("/c"),
+		stylesheetAttrs("/d"),
+		stylesheetAttrs("/e"),
+	}
+	expected := [][]html.Attribute{
+		stylesheetAttrs("/a"),
+		stylesheetAttrs("/c"),
+		stylesheetAttrs("/e"),
+	}
+	result := stylesheetDeduplicationStrategy.Deduplicate(stylesheets)
+	a.EqualValues(expected, result)
+}

--- a/composition_example/example_ui_service.go
+++ b/composition_example/example_ui_service.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	gorilla "github.com/gorilla/handlers"
-	"github.com/tarent/lib-compose/composition"
 	"net/http"
 	"os"
+
+	gorilla "github.com/gorilla/handlers"
+	"github.com/tarent/lib-compose/composition"
 )
 
 var host = "127.0.0.1:8080"
@@ -41,7 +42,7 @@ func compositionHandler() http.Handler {
 
 		return fetcher
 	}
-	return composition.NewCompositionHandler(contentFetcherFactory)
+	return composition.NewCompositionHandler(contentFetcherFactory).WithDeduplicationStrategy(new(composition.SimpleDeduplicationStrategy))
 }
 
 func staticHandler() http.Handler {

--- a/composition_example/example_ui_service_test.go
+++ b/composition_example/example_ui_service_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -27,11 +28,18 @@ func Test_integration_test(t *testing.T) {
 
 	expected, err := ioutil.ReadFile("./expected_test_result.html")
 	expectedS := strings.Replace(string(expected), "http://127.0.0.1:8080", s.URL, -1)
-
+	expectedS = removeEmptyLines(expectedS)
+	result := removeEmptyLines(string(body))
 	a.NoError(err)
-	htmlEqual(t, expectedS, string(body))
+	htmlEqual(t, expectedS, result)
 }
 
 func htmlEqual(t *testing.T, expected, actual string) {
 	assert.Equal(t, gohtml.Format(expected), gohtml.Format(actual))
+}
+
+func removeEmptyLines(stringToProcess string) string {
+	re := regexp.MustCompile(`(?m)^\s*$[\r\n]*|[\r\n]+\s+\z`)
+	stringToProcess = re.ReplaceAllString(stringToProcess, "")
+	return stringToProcess
 }

--- a/composition_example/example_ui_service_test.go
+++ b/composition_example/example_ui_service_test.go
@@ -28,10 +28,6 @@ func Test_integration_test(t *testing.T) {
 	expected, err := ioutil.ReadFile("./expected_test_result.html")
 	expectedS := strings.Replace(string(expected), "http://127.0.0.1:8080", s.URL, -1)
 
-	// debug - don't commit!
-	ioutil.WriteFile("/tmp/expected", []byte(expectedS), 0644)
-	ioutil.WriteFile("/tmp/result", body, 0644)
-
 	a.NoError(err)
 	htmlEqual(t, expectedS, string(body))
 }

--- a/composition_example/expected_test_result.html
+++ b/composition_example/expected_test_result.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    
     <link rel="stylesheet" href="/static/head/layout.css">
+    <link rel="stylesheet" href="/static/head/lorem.css" type="text/css" media="screen" title="content" charset="utf-8">
     <link rel="stylesheet" href="/static/head/styles/stylesheet.css">
     <link rel="stylesheet" href="/static/head/basic.css" type="text/css" media="screen" title="no title" charset="utf-8">
     <link rel="stylesheet" href="/static/body/layout1.css">
@@ -15,35 +15,26 @@
     <link rel="stylesheet" href="/static/tail/styles/stylesheet.css">
   </head>
   <body>
-    
       <div class="header-box">
         The Header: Hello World!
       </div>
-    
-    
       <div class="header-box">
-          
         The Subheader
       </div>
-    
     <div class="teaser">This is a dynamic teaser for id t001</div>
-      
     <p></p>
     <ul>
       <li><a href="http://127.0.0.1:8080?text=Something">Set Text: Something</a></li>
       <li><a href="http://127.0.0.1:8080?text=Else">Set Text: Else</a></li>
     </ul>
     Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
-    
       <hr>
       <small>The footer</small>
-      
       <script src="https://code.jquery.com/jquery-2.2.3.min.js"></script>
       <script>
        $(function() {
          $('<div>some dynamic text at the end</div>').appendTo('body');
        })    
       </script>
-    
   </body>
 </html>

--- a/composition_example/static/basic.html
+++ b/composition_example/static/basic.html
@@ -2,6 +2,7 @@
   <head>
     <link rel="stylesheet" href="/static/head/basic.css" type="text/css" media="screen" title="no title" charset="utf-8">
     <link uic-remove rel="stylesheet" href="removed.basic.css">
+    <link rel="stylesheet" href="/static/head/basic.css" type="text/css" media="screen" title="no title" charset="utf-8">
   </head>
   <body>
     <h1 uic-remove>Basic Web Elements</h1>
@@ -10,15 +11,18 @@
       <link rel="stylesheet" href="/static/body/basic.css#header">
       <link rel="stylesheet" href="/static/body/basic2.css#header">
       <link rel="stylesheet" href="/static/body/basic3.css#header">
+      <link rel="stylesheet" href="/static/head/basic.css" type="text/css" media="screen" title="no title" charset="utf-8">
       <div class="header-box">
         The Header: §[header_text]§
       </div>
     </uic-fragment>
 
+    <link rel="stylesheet" href="/static/head/basic.css" type="text/css" media="screen" title="no title" charset="utf-8">
     <h3 uic-remove>The Subheader</h3>
     <uic-fragment name="subheader">
       <div class="header-box">
           <link rel="stylesheet" href="/static/body/basic.css#subheader">
+          <link rel="stylesheet" href="/static/head/basic.css" type="text/css" media="screen" title="no title" charset="utf-8">
         The Subheader
       </div>
     </uic-fragment>
@@ -27,7 +31,9 @@
     <uic-fragment name="footer">
       <hr>
       <small>The footer</small>
+      <link rel="stylesheet" href="/static/head/basic.css" type="text/css" media="screen" title="no title" charset="utf-8">
       <link rel="stylesheet" href="/static/body/basic.css#footer">
+      <link rel="stylesheet" href="/static/head/basic.css" type="text/css" media="screen" title="no title" charset="utf-8">
     </uic-fragment>
   </body>
 </html>

--- a/composition_example/static/layout.html
+++ b/composition_example/static/layout.html
@@ -12,6 +12,8 @@
     <uic-include src="content" required="true"/>
     <uic-include src="basic#footer" required="true"/>
     <uic-include src="missing_fragment"/>
+    <link rel="stylesheet" href="/static/head/basic.css" type="text/css" media="screen" title="no title" charset="utf-8">
     <link rel="stylesheet" href="/static/body/layout2.css">
+    <link rel="stylesheet" href="/static/head/basic.css" type="text/css" media="screen" title="no title" charset="utf-8">
   </body>
 </html>

--- a/composition_example/static/lorem.html
+++ b/composition_example/static/lorem.html
@@ -1,12 +1,15 @@
 <html>
   <head>
+    <link rel="stylesheet" href="/static/head/lorem.css" type="text/css" media="screen" title="content" charset="utf-8">
   </head>
   <body>
+    <link rel="stylesheet" href="/static/head/basic.css" type="text/css" media="screen" title="no title" charset="utf-8">
     <p>§[request.params.text]§</p>
     <ul>
       <li><a href="§[request.base_url]§?text=Something">Set Text: Something</a></li>
       <li><a href="§[request.base_url]§?text=Else">Set Text: Else</a></li>
     </ul>
+    <link rel="stylesheet" href="/static/head/basic.css" type="text/css" media="screen" title="no title" charset="utf-8">
     Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. 
   </body>
 </html>


### PR DESCRIPTION
The user of the library can implement her own strategy and set it via
composition.SetStrategy().

The library will provide two strategies:
- IdentityDeduplicationStrategy (NOOP strategy)
- SimpleDeduplicationStrategy (uniqueness by the full href path to stylesheets)