### PR TITLE
Some FetchDefinitions should not be removed from cache if there was a…

### DIFF
--- a/composition/composition_handler.go
+++ b/composition/composition_handler.go
@@ -89,9 +89,17 @@ func (agg *CompositionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
 	html, err := agg.processHtml(mergeContext, w, r)
-	// Return if an error occured within the html aggregation
+	// Return if an error occured within the html aggregation and
+	// remove potentially erroneous results from cache
 	if err != nil {
-		agg.purgeCacheEntries(results)
+		//Filter without allocating
+		resultsToPurge := results[:0]
+		for _, res := range results {
+			if !res.Def.NoPurgeOnMergeError {
+				resultsToPurge = append(resultsToPurge, res)
+			}
+		}
+		agg.purgeCacheEntries(resultsToPurge)
 		return
 	}
 

--- a/composition/fetch_definition.go
+++ b/composition/fetch_definition.go
@@ -76,20 +76,25 @@ type FetchDefinition struct {
 	ServiceDiscoveryActive bool
 	ServiceDiscovery       servicediscovery.ServiceDiscovery
 	Priority               int
+	// Defines whether the result of this FD should remain cached
+	// even if all cached entries of an erroneous context are removed
+	// (e.g. the FD relates to a central component which is used everywhere)
+	NoPurgeOnMergeError bool
 }
 
 // Creates a fetch definition (warning: this one will not forward any request headers).
 func NewFetchDefinition(url string) *FetchDefinition {
 	return &FetchDefinition{
-		Name:            urlToName(url), // the name defauls to the url
-		URL:             url,
-		Timeout:         DefaultTimeout,
-		FollowRedirects: false,
-		Required:        true,
-		Method:          "GET",
-		ErrHandler:      NewDefaultErrorHandler(),
-		CacheStrategy:   cache.DefaultCacheStrategy,
-		Priority:        DefaultPriority,
+		Name:                urlToName(url), // the name defauls to the url
+		URL:                 url,
+		Timeout:             DefaultTimeout,
+		FollowRedirects:     false,
+		Required:            true,
+		Method:              "GET",
+		ErrHandler:          NewDefaultErrorHandler(),
+		CacheStrategy:       cache.DefaultCacheStrategy,
+		Priority:            DefaultPriority,
+		NoPurgeOnMergeError: false,
 	}
 }
 
@@ -136,6 +141,11 @@ func (fd *FetchDefinition) WithResponseProcessor(rp ResponseProcessor) *FetchDef
 // Set a name to be used in the merge context later on
 func (fd *FetchDefinition) WithName(name string) *FetchDefinition {
 	fd.Name = name
+	return fd
+}
+
+func (fd *FetchDefinition) ShouldSurviveContextPurge(shouldSurvive bool) *FetchDefinition {
+	fd.NoPurgeOnMergeError = shouldSurvive
 	return fd
 }
 


### PR DESCRIPTION
…n error in a context they were a part of. (For example a site navigation if some random page threw a 404)