### PR TITLE
Prefer using a strategy factory to set the deduplication strategy per…

### DIFF
--- a/composition/composition_handler.go
+++ b/composition/composition_handler.go
@@ -46,12 +46,12 @@ func (agg *CompositionHandler) WithCache(cache Cache) *CompositionHandler {
 
 // Set the deduplication strategy to be used by the constructed content merger
 // This method will first take effect in the upcomping call of ServeHTTP()
-func (agg *CompositionHandler) WithDeduplicationStrategy(strategy StylesheetDeduplicationStrategy) *CompositionHandler {
+func (agg *CompositionHandler) WithDeduplicationStrategyFactory(strategyFactory func() StylesheetDeduplicationStrategy) *CompositionHandler {
 	wrapped := agg.contentMergerFactory
 	agg.contentMergerFactory = func(metaJSON map[string]interface{}) ContentMerger {
 		cm := wrapped(metaJSON)
 		if cm != nil {
-			cm.SetDeduplicationStrategy(strategy)
+			cm.SetDeduplicationStrategy(strategyFactory())
 		}
 		return cm
 	}

--- a/composition/composition_handler_test.go
+++ b/composition/composition_handler_test.go
@@ -89,10 +89,10 @@ func Test_CompositionHandler_PositiveCaseWithSimpleDeduplicationStrategy(t *test
 		}
 	}
 	ch := NewCompositionHandler(ContentFetcherFactory(contentFetcherFactory))
-	sdf := func() StylesheetDeduplicationStrategy {
+	factory := func() StylesheetDeduplicationStrategy {
 		return new(SimpleDeduplicationStrategy)
 	}
-	ch.WithDeduplicationStrategyFactory(sdf)
+	ch.WithDeduplicationStrategyFactory(factory)
 
 	resp := httptest.NewRecorder()
 	r, _ := http.NewRequest("GET", "http://example.com", nil)

--- a/composition/composition_handler_test.go
+++ b/composition/composition_handler_test.go
@@ -89,7 +89,10 @@ func Test_CompositionHandler_PositiveCaseWithSimpleDeduplicationStrategy(t *test
 		}
 	}
 	ch := NewCompositionHandler(ContentFetcherFactory(contentFetcherFactory))
-	ch.WithDeduplicationStrategy(new(SimpleDeduplicationStrategy))
+	sdf := func() StylesheetDeduplicationStrategy {
+		return new(SimpleDeduplicationStrategy)
+	}
+	ch.WithDeduplicationStrategyFactory(sdf)
 
 	resp := httptest.NewRecorder()
 	r, _ := http.NewRequest("GET", "http://example.com", nil)

--- a/composition_example/example_ui_service.go
+++ b/composition_example/example_ui_service.go
@@ -42,7 +42,10 @@ func compositionHandler() http.Handler {
 
 		return fetcher
 	}
-	return composition.NewCompositionHandler(contentFetcherFactory).WithDeduplicationStrategy(new(composition.SimpleDeduplicationStrategy))
+	sdf := func() composition.StylesheetDeduplicationStrategy {
+		return new(composition.SimpleDeduplicationStrategy)
+	}
+	return composition.NewCompositionHandler(contentFetcherFactory).WithDeduplicationStrategyFactory(sdf)
 }
 
 func staticHandler() http.Handler {

--- a/composition_example/example_ui_service.go
+++ b/composition_example/example_ui_service.go
@@ -42,10 +42,10 @@ func compositionHandler() http.Handler {
 
 		return fetcher
 	}
-	sdf := func() composition.StylesheetDeduplicationStrategy {
+	factory := func() composition.StylesheetDeduplicationStrategy {
 		return new(composition.SimpleDeduplicationStrategy)
 	}
-	return composition.NewCompositionHandler(contentFetcherFactory).WithDeduplicationStrategyFactory(sdf)
+	return composition.NewCompositionHandler(contentFetcherFactory).WithDeduplicationStrategyFactory(factory)
 }
 
 func staticHandler() http.Handler {


### PR DESCRIPTION
… ContentMerger.

Otherwise one deduplication strategy instance is used for all
ContentMerger instances, wich will cause concurrency issues and missing
data, if the strategy has state.