### PR TITLE
Merge body attributes

### DIFF
--- a/composition/content_merge.go
+++ b/composition/content_merge.go
@@ -202,11 +202,11 @@ func (cntx *ContentMerge) GetBodyFragmentByName(name string) (Fragment, bool) {
 
 func (cntx *ContentMerge) AddContent(c Content, priority int) {
 	cntx.addHead(c.Head())
-	content2, ok := c.(Content2)
+	contentV2, ok := c.(ContentV2)
 	if ok {
-		cntx.addBodyAttributesArray(content2.BodyAttributesArray())
+		cntx.addBodyAttributesArray(contentV2.BodyAttributesArray())
 	} else {
-		logging.Logger.Warnf("This body-content will not be rendered. Change type of c to Content2")
+		logging.Logger.Warnf("This body-content will not be rendered. Change type of c to ContentV2")
 	}
 	cntx.addBody(c)
 	cntx.addTail(c.Tail())

--- a/composition/content_merge_test.go
+++ b/composition/content_merge_test.go
@@ -51,7 +51,7 @@ func Test_ContentMerge_PositiveCase(t *testing.T) {
 	cm.AddContent(&MemoryContent{
 		name:           LayoutFragmentName,
 		head:           NewStringFragment("<page1-head/>\n"),
-		bodyAttributes: NewStringFragment(`a="b"`),
+		bodyAttributes: htmlAttributes(map[string]string{"a": "b"}),
 		tail:           NewStringFragment("    <page1-tail/>\n"),
 		body:           map[string]Fragment{"": body},
 	}, 0)
@@ -59,7 +59,7 @@ func Test_ContentMerge_PositiveCase(t *testing.T) {
 	cm.AddContent(&MemoryContent{
 		name:           "example.com",
 		head:           NewStringFragment("    <page2-head/>\n"),
-		bodyAttributes: NewStringFragment(`foo="bar"`),
+		bodyAttributes: htmlAttributes(map[string]string{"foo": "bar"}),
 		tail:           NewStringFragment("    <page2-tail/>"),
 		body: map[string]Fragment{
 			"page2-a": NewStringFragment("<page2-body-a/>"),
@@ -251,4 +251,12 @@ func (buff closedWriterMock) Write(b []byte) (int, error) {
 
 func asFetchResult(c Content) *FetchResult {
 	return &FetchResult{Content: c, Def: &FetchDefinition{URL: c.Name()}}
+}
+
+func htmlAttributes(m map[string]string) []html.Attribute {
+	var result []html.Attribute
+	for k, v := range m {
+		result = append(result, html.Attribute{Key: k, Val: v})
+	}
+	return result
 }

--- a/composition/html_content_parser_test.go
+++ b/composition/html_content_parser_test.go
@@ -299,7 +299,7 @@ func Test_HtmlContentParser_parseHead_withMultipleMetaTags_and_Titles_and_Canoni
 	err := parser.parseHead(z, c)
 	a.NoError(err)
 
-        containsFragment(t, "<title>navigationservice</title>", c.Head())
+	containsFragment(t, "<title>navigationservice</title>", c.Head())
 }
 
 func Test_HtmlContentParser_parseHead(t *testing.T) {
@@ -449,7 +449,7 @@ func Test_HtmlContentParser_parseBody(t *testing.T) {
 		`§[> local]§`, c.Body()["content"])
 	eqFragment(t, "<!-- tail -->§[> example.com/tail]§", c.Tail())
 
-	eqFragment(t, `some="attribute"`, c.BodyAttributes())
+	a.Equal(`some="attribute"`, joinAttrs(c.BodyAttributes()))
 
 	a.Equal(5, len(c.Dependencies()))
 	a.Equal(c.Dependencies()["example.com/xyz"], Params{"foo": "bar", "bazz": "buzz"})
@@ -746,7 +746,6 @@ func containsFragment(t *testing.T, contained string, f Fragment) {
 	}
 }
 
-
 func Test_ParseHeadFragment_Filter_Title(t *testing.T) {
 	a := assert.New(t)
 
@@ -942,7 +941,7 @@ func Test_ParseHeadFragment_Filter_Meta_Tag(t *testing.T) {
 func Test_ParseHeadFragment_Filter_Link_Canonical_Tag(t *testing.T) {
 	a := assert.New(t)
 
-        // GIVEN
+	// GIVEN
 	originalHeadString := `<meta charset="utf-8">
 
 	<link rel="canonical" href="/navigationservice">
@@ -1011,10 +1010,10 @@ func Test_ParseHeadFragment_Filter_Link_Canonical_Tag(t *testing.T) {
 	headMetaPropertyMap["canonical"] = "/baumarkt/suche"
 
 	headFragment := NewStringFragment(originalHeadString)
-        // WHEN
+	// WHEN
 	ParseHeadFragment(headFragment, headMetaPropertyMap)
 
-        // THEN
+	// THEN
 	expectedParsedHead = removeTabsAndNewLines(expectedParsedHead)
 	resultString := removeTabsAndNewLines(headFragment.Content())
 
@@ -1022,7 +1021,7 @@ func Test_ParseHeadFragment_Filter_Link_Canonical_Tag(t *testing.T) {
 }
 
 func Test_ParseHeadFragment_Filter_Link_Canonical_Tag_without_existing_Map(t *testing.T) {
-        // GIVEN
+	// GIVEN
 	a := assert.New(t)
 
 	originalHeadString := `
@@ -1049,10 +1048,10 @@ func Test_ParseHeadFragment_Filter_Link_Canonical_Tag_without_existing_Map(t *te
 	headMetaPropertyMap := make(map[string]string)
 
 	headFragment := NewStringFragment(originalHeadString)
-        // WHEN
+	// WHEN
 	ParseHeadFragment(headFragment, headMetaPropertyMap)
 
-        // THEN
+	// THEN
 	expectedParsedHead = removeTabsAndNewLines(expectedParsedHead)
 	resultString := removeTabsAndNewLines(headFragment.Content())
 

--- a/composition/html_content_parser_test.go
+++ b/composition/html_content_parser_test.go
@@ -449,7 +449,10 @@ func Test_HtmlContentParser_parseBody(t *testing.T) {
 		`§[> local]§`, c.Body()["content"])
 	eqFragment(t, "<!-- tail -->§[> example.com/tail]§", c.Tail())
 
-	a.Equal(`some="attribute"`, joinAttrs(c.BodyAttributes()))
+	a.Equal(`some="attribute"`, joinAttrs(c.BodyAttributesArray()))
+
+	// check deprecated BodyAttributes() method
+	eqFragment(t, `some="attribute"`, c.BodyAttributes())
 
 	a.Equal(5, len(c.Dependencies()))
 	a.Equal(c.Dependencies()["example.com/xyz"], Params{"foo": "bar", "bazz": "buzz"})

--- a/composition/interface_mocks_test.go
+++ b/composition/interface_mocks_test.go
@@ -5,7 +5,8 @@ package composition
 
 import (
 	gomock "github.com/golang/mock/gomock"
-
+	
+	html "golang.org/x/net/html"
 	io "io"
 	http "net/http"
 )
@@ -49,6 +50,16 @@ func (_m *MockFragment) MemorySize() int {
 
 func (_mr *_MockFragmentRecorder) MemorySize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MemorySize")
+}
+
+func (_m *MockFragment) Stylesheets() [][]html.Attribute {
+	ret := _m.ctrl.Call(_m, "Stylesheets")
+	ret0, _ := ret[0].([][]html.Attribute)
+	return ret0
+}
+
+func (_mr *_MockFragmentRecorder) Stylesheets() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Stylesheets")
 }
 
 // Mock of ContentLoader interface
@@ -114,9 +125,9 @@ func (_mr *_MockContentRecorder) Body() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Body")
 }
 
-func (_m *MockContent) BodyAttributes() Fragment {
+func (_m *MockContent) BodyAttributes() []html.Attribute {
 	ret := _m.ctrl.Call(_m, "BodyAttributes")
-	ret0, _ := ret[0].(Fragment)
+	ret0, _ := ret[0].([]html.Attribute)
 	return ret0
 }
 
@@ -260,11 +271,16 @@ func (_m *MockContentMerger) GetHtml() ([]byte, error) {
 	return ret0, ret1
 }
 
-func (_m *MockContentMerger) SetDeduplicationStrategy(strategy StylesheetDeduplicationStrategy) {
-}
-
 func (_mr *_MockContentMergerRecorder) GetHtml() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetHtml")
+}
+
+func (_m *MockContentMerger) SetDeduplicationStrategy(_param0 StylesheetDeduplicationStrategy) {
+	_m.ctrl.Call(_m, "SetDeduplicationStrategy", _param0)
+}
+
+func (_mr *_MockContentMergerRecorder) SetDeduplicationStrategy(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetDeduplicationStrategy", arg0)
 }
 
 // Mock of ContentParser interface

--- a/composition/interface_mocks_test.go
+++ b/composition/interface_mocks_test.go
@@ -125,14 +125,24 @@ func (_mr *_MockContentRecorder) Body() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Body")
 }
 
-func (_m *MockContent) BodyAttributes() []html.Attribute {
+func (_m *MockContent) BodyAttributes() Fragment {
 	ret := _m.ctrl.Call(_m, "BodyAttributes")
-	ret0, _ := ret[0].([]html.Attribute)
+	ret0, _ := ret[0].(Fragment)
 	return ret0
 }
 
 func (_mr *_MockContentRecorder) BodyAttributes() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BodyAttributes")
+}
+
+func (_m *MockContent) BodyAttributesArray() []html.Attribute {
+	ret := _m.ctrl.Call(_m, "BodyAttributesArray")
+	ret0, _ := ret[0].([]html.Attribute)
+	return ret0
+}
+
+func (_mr *_MockContentRecorder) BodyAttributesArray() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BodyAttributesArray")
 }
 
 func (_m *MockContent) Dependencies() map[string]Params {

--- a/composition/interfaces.go
+++ b/composition/interfaces.go
@@ -52,7 +52,7 @@ type CacheStrategy interface {
 // Params is a value type for a parameter map
 type Params map[string]string
 
-// Vontent is the abstration over includable data.
+// Content is the abstraction over includable data.
 // Content may be parsed of it may contain a stream represented by a non nil Reader(), not both.
 type Content interface {
 
@@ -82,8 +82,8 @@ type Content interface {
 	// e.g. a script to load after rendering.
 	Tail() Fragment
 
-	// The attributes for the body element
-	BodyAttributes() []html.Attribute
+	// Deprecated: Return the attributes for the body element as Fragment.
+	BodyAttributes() Fragment
 
 	// Reader returns the stream with the content, of any.
 	// If Reader() == nil, no stream is available an it contains parsed data, only.
@@ -97,6 +97,13 @@ type Content interface {
 
 	// MemorySize return the estimated size in bytes, for this object in memory
 	MemorySize() int
+}
+
+type Content2 interface {
+	Content
+
+	// Return the attributes for the body element as array.
+	BodyAttributesArray() []html.Attribute
 }
 
 type ContentMerger interface {

--- a/composition/interfaces.go
+++ b/composition/interfaces.go
@@ -83,7 +83,7 @@ type Content interface {
 	Tail() Fragment
 
 	// The attributes for the body element
-	BodyAttributes() Fragment
+	BodyAttributes() []html.Attribute
 
 	// Reader returns the stream with the content, of any.
 	// If Reader() == nil, no stream is available an it contains parsed data, only.

--- a/composition/interfaces.go
+++ b/composition/interfaces.go
@@ -99,7 +99,7 @@ type Content interface {
 	MemorySize() int
 }
 
-type Content2 interface {
+type ContentV2 interface {
 	Content
 
 	// Return the attributes for the body element as array.

--- a/composition/memory_content.go
+++ b/composition/memory_content.go
@@ -3,6 +3,8 @@ package composition
 import (
 	"io"
 	"net/http"
+
+	"golang.org/x/net/html"
 )
 
 type MemoryContent struct {
@@ -13,7 +15,7 @@ type MemoryContent struct {
 	head            Fragment
 	body            map[string]Fragment
 	tail            Fragment
-	bodyAttributes  Fragment
+	bodyAttributes  []html.Attribute
 	reader          io.ReadCloser
 	httpHeader      http.Header
 	httpStatusCode  int
@@ -77,7 +79,7 @@ func (c *MemoryContent) Tail() Fragment {
 	return c.tail
 }
 
-func (c *MemoryContent) BodyAttributes() Fragment {
+func (c *MemoryContent) BodyAttributes() []html.Attribute {
 	return c.bodyAttributes
 }
 

--- a/composition/memory_content.go
+++ b/composition/memory_content.go
@@ -79,7 +79,12 @@ func (c *MemoryContent) Tail() Fragment {
 	return c.tail
 }
 
-func (c *MemoryContent) BodyAttributes() []html.Attribute {
+// Deprecated: This method is deprecated
+func (c *MemoryContent) BodyAttributes() Fragment {
+	return NewStringFragment(joinAttrs(c.bodyAttributes))
+}
+
+func (c *MemoryContent) BodyAttributesArray() []html.Attribute {
 	return c.bodyAttributes
 }
 


### PR DESCRIPTION
This fixes the issue, when multiple <body> tags are merged with identical attributes.
'class' attributes are merged together, other duplicate attributes overwrite their predecessors.